### PR TITLE
Add workflow for Firebase App Distribution

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: App Distribution
+on:
+  push:
+    paths: 
+    - elaichi/**
+    branches:
+    - development
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v1
+      with:
+        java-version: "12.x"
+    - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "1.22.5"
+          channel: "stable"
+    - name: Get packages
+      working-directory: ./elaichi
+      run: flutter pub get
+    - name: Build APK
+      working-directory: ./elaichi
+      run: flutter build apk --release
+    - name: Decode Service Account
+      run: echo ${{secrets.SERVICE_ACCOUNT}} | base64 --decode > sa.json
+    - name: Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.3.2
+        with:
+          appId: ${{secrets.APP_ID}}
+          serviceCredentialsFile: sa.json
+          token: ${{secrets.FIREBASE_TOKEN}}
+          groups: alpha-testers
+          file: elaichi/app/build/outputs/flutter-apk/app-release.apk
+

--- a/elaichi/android/.gitignore
+++ b/elaichi/android/.gitignore
@@ -4,4 +4,5 @@ gradle-wrapper.jar
 /gradlew
 /gradlew.bat
 /local.properties
+/key.properties
 GeneratedPluginRegistrant.java

--- a/elaichi/android/app/build.gradle
+++ b/elaichi/android/app/build.gradle
@@ -25,6 +25,24 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keyStoreProperties = new Properties()
+def keyStorePropertiesFile = rootProject.file('key.properties')
+if(keyStorePropertiesFile.exists()){
+    keyStoreProperties.load(new FileInputStream(keyStorePropertiesFile))
+}
+
+def dartEnvironmentVariables = [
+    ENV: null
+];
+if(project.hasProperty('dart-defines')) {
+    dartEnvironmentVariables = dartEnvironmentVariables + project.property('dart-defines')
+        .split(',')
+        .collectEntries { entry ->
+            def pair = URLDecoder.decode(entry).split('=')
+            [(pair.first()): pair.last()]
+        }
+}
+
 android {
     compileSdkVersion 28
 
@@ -37,8 +55,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "tech.dscnitr.elaichi"
+        applicationId "org.dscnitrourkela.elaichi"
         minSdkVersion 16
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
@@ -46,10 +63,24 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs{
+        release {
+            keyAlias keyStoreProperties['keyAlias']
+            keyPassword keyStoreProperties['keyPassword']
+            storeFile keyStoreProperties['storeFile'] ? file(keyStoreProperties['storeFile']) : null
+            storePassword keyStoreProperties['storePassword']
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
+            if(dartEnvironmentVariables.ENV == null){
+                signingConfig signingConfigs.debug
+            } else{
+                signingConfig signingConfigs.release
+            }
+        }
+        debug {
             signingConfig signingConfigs.debug
         }
     }

--- a/elaichi/android/app/src/debug/AndroidManifest.xml
+++ b/elaichi/android/app/src/debug/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tech.dscnitr.elaichi">
+    package="org.dscnitrourkela.elaichi">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->

--- a/elaichi/android/app/src/main/AndroidManifest.xml
+++ b/elaichi/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tech.dscnitr.elaichi">
+    package="org.dscnitrourkela.elaichi">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/elaichi/android/app/src/main/kotlin/org/dscnitrourkela/elaichi/MainActivity.kt
+++ b/elaichi/android/app/src/main/kotlin/org/dscnitrourkela/elaichi/MainActivity.kt
@@ -1,4 +1,4 @@
-package tech.dscnitr.elaichi
+package org.dscnitrourkela.elaichi
 
 import androidx.annotation.NonNull;
 import io.flutter.embedding.android.FlutterActivity

--- a/elaichi/android/app/src/profile/AndroidManifest.xml
+++ b/elaichi/android/app/src/profile/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="tech.dscnitr.elaichi">
+    package="org.dscnitrourkela.elaichi">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->


### PR DESCRIPTION
See: [Dart define environment variables and using them in android](https://itnext.io/flutter-1-17-no-more-flavors-no-more-ios-schemas-command-argument-that-solves-everything-8b145ed4285d). 
Workflow added for alpha testers to start receiving test builds in their emails via Firebase App Distribution. The workflow is specified in `.github/workflows/build.yaml`. Workflow will be triggered when a commit is pushed to `development` branch and there are changes in `elaichi` directory. `build.gradle(app)` is now configured to generate release APK with debug signing keys for CI and local environments. Run `flutter build apk --release` for this. To generate a signed APK/AAB for pushing to Google Play Store, run: `flutter build apk(or appbundle) --release --dart-define=ENV=prod`.
